### PR TITLE
ADP-68

### DIFF
--- a/packages/frontend/src/sections/project/detalle/notes-tab/notes-form/index.tsx
+++ b/packages/frontend/src/sections/project/detalle/notes-tab/notes-form/index.tsx
@@ -8,6 +8,7 @@ import LoadingButton from '@mui/lab/LoadingButton'
 import { CREATE_PROJECT_NOTE } from 'src/graphql/mutations'
 import { IProject } from '@adp/shared'
 import FormProvider, { RHFTextField } from 'src/components/hook-form'
+import { enqueueSnackbar } from 'notistack'
 
 // ----------------------------------------------------------------------
 type TProps = {
@@ -50,6 +51,7 @@ export default function PostCommentForm(props: TProps) {
       refetch()
     } catch (error) {
       console.error(error)
+      enqueueSnackbar(`La nota no pudo ser creada`, { variant: 'error' })
     }
   })
 


### PR DESCRIPTION
Mostrar el cartel de error al no poder crear una nota por x motivo.
![image](https://github.com/harecode-ar/ADP/assets/72807139/f6271c96-648f-42a6-a8d4-4892e45d6c01)
