### PR TITLE
Componente de costos de proyectos por areas

### DIFF
--- a/packages/frontend/src/sections/tablero/report-tab/component-four.tsx
+++ b/packages/frontend/src/sections/tablero/report-tab/component-four.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import Card from '@mui/material/Card'
+import Chart, { useChart } from 'src/components/chart'
+import { useTheme } from '@mui/material/styles'
+import { fCurrency } from 'src/utils/format-number'
+
+type TProps = {
+  newProjects: number
+  inProgressProjects: number
+  finishedProjects: number
+  canceledProjects: number
+}
+
+export default function ComponentTwo(props: TProps) {
+  const { newProjects, inProgressProjects, finishedProjects, canceledProjects } = props
+
+  const theme = useTheme()
+
+  const chartOptions = useChart({
+    stroke: {
+      show: true,
+      width: 0,
+      colors: ['transparent'],
+    },
+    xaxis: {
+      categories: ['Nuevos', 'En proceso', 'Finalizados', 'Cancelados'],
+    },
+    yaxis: {
+      labels: {
+        show: false,
+      },
+    },
+    tooltip: {
+      y: {
+        formatter: (value: number) => `${fCurrency(value).replace('.', ';').replace(/,/g, '.').replace(';', ',')}`,
+      },
+    },
+    plotOptions: {
+      bar: { horizontal: true },
+    },
+    colors: [
+      theme.palette.info.dark,
+      theme.palette.warning.main,
+      theme.palette.success.main,
+      theme.palette.text.secondary,
+    ],
+  })
+
+  return (
+    <Card sx={{
+      width: '100%',
+    }}>
+      <Card sx={{
+        p: 2,
+        pl: 0
+      }}>
+        <Chart
+          dir="ltr"
+          type="bar"
+          series={[
+            { name: 'Nuevos', data: [newProjects, 0, 0, 0] },
+            { name: 'En proceso', data: [0, inProgressProjects, 0, 0] },
+            { name: 'Finalizados', data: [0, 0, finishedProjects, 0] },
+            { name: 'Cancelados', data: [0, 0, 0, canceledProjects] },
+          ]}
+          options={chartOptions}
+          width="100%"
+          height={320}
+        />
+      </Card>
+    </Card>
+  )
+}

--- a/packages/frontend/src/sections/tablero/report-tab/index.tsx
+++ b/packages/frontend/src/sections/tablero/report-tab/index.tsx
@@ -4,7 +4,8 @@ import FilterComponent from './filter-component'
 import ComponentOne from './component-one'
 import ComponentTwo from './component-two'
 import ComponentThree from './component-three'
-import { PROJECT_COUNT_BY_STATE } from '../../../mocks/report'
+import ComponentFour from './component-four'
+import { PROJECT_COUNT_BY_STATE, PROJECT_COST_BY_STATE } from '../../../mocks/report'
 
 export default function ReportTab() {
   const newProjects = PROJECT_COUNT_BY_STATE.new
@@ -12,6 +13,12 @@ export default function ReportTab() {
   const finishedProjects = PROJECT_COUNT_BY_STATE.completed
   const canceledProjects = PROJECT_COUNT_BY_STATE.cancelled
   const totalProjects = PROJECT_COUNT_BY_STATE.count
+
+  const newProjectsCost = PROJECT_COST_BY_STATE.new
+  const inProgressProjectsCost = PROJECT_COST_BY_STATE.inProgress
+  const finishedProjectsCost = PROJECT_COST_BY_STATE.completed
+  const canceledProjectsCost = PROJECT_COST_BY_STATE.cancelled
+  const totalProjectsCost = PROJECT_COST_BY_STATE.count
 
   return (
     <Box sx={{
@@ -43,6 +50,25 @@ export default function ReportTab() {
             inProgressProjects={inProgressProjects}
             finishedProjects={finishedProjects}
             canceledProjects={canceledProjects}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={4}>
+          <ComponentThree
+            newProjects={newProjectsCost}
+            inProgressProjects={inProgressProjectsCost}
+            finishedProjects={finishedProjectsCost}
+            canceledProjects={canceledProjectsCost}
+            totalProjects={totalProjectsCost}
+          />
+        </Grid>
+        <Grid item xs={12} md={8}>
+          <ComponentFour
+            newProjects={newProjectsCost}
+            inProgressProjects={inProgressProjectsCost}
+            finishedProjects={finishedProjectsCost}
+            canceledProjects={canceledProjectsCost}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
Se agrega un nuevo componente para mostrar los costos de los proyectos por areas.

<img width="716" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/87b1b6f7-959b-49fa-a709-c99a7f76b82c">
