### PR TITLE
Fix responsibleId null value in EditAreaModal

### DIFF
--- a/packages/frontend/src/sections/area/detalle/edit-area-modal.tsx
+++ b/packages/frontend/src/sections/area/detalle/edit-area-modal.tsx
@@ -100,7 +100,7 @@ const EditAreaModal = (props: TProps) => {
             color: values.color.color,
             rolename: 'prueba',
             multiple: false,
-            responsibleId: values.responsible?.id,
+            responsibleId: values.responsible?.id || null,
             parentId: values.parent?.id,
           },
         })

--- a/packages/frontend/src/sections/area/organigrama/edit-area-modal.tsx
+++ b/packages/frontend/src/sections/area/organigrama/edit-area-modal.tsx
@@ -98,7 +98,7 @@ const EditAreaModal = (props: TProps) => {
             color: values.color.color,
             rolename: 'prueba',
             multiple: false,
-            responsibleId: values.responsible?.id,
+            responsibleId: values.responsible?.id || null,
             parentId: values.parent?.id,
           },
         })


### PR DESCRIPTION
Al editar el area, se puede borrar el responsable y dejarlo sin responsable