### PR TITLE
Refactor avatar styling in AreaCard component

### DIFF
--- a/packages/frontend/src/sections/tablero/area-tab/index.tsx
+++ b/packages/frontend/src/sections/tablero/area-tab/index.tsx
@@ -148,7 +148,12 @@ function AreaCard({ area }: AreaCardProps) {
             <Avatar
               alt={responsible?.fullname || 'Sin responsable'}
               src={responsible?.image ? getStorageFileUrl(responsible.image) : '/broken-image.jpg'}
-              sx={{ width: 64, height: 64, mb: 3 }}
+              sx={(theme) => ({
+                width: 64,
+                height: 64,
+                marginBottom: 3,
+                border: `2px solid ${theme.palette.primary.main}`,
+              })}
             />
 
             <Typography


### PR DESCRIPTION
Se agrega un border en el avatar de las tarjetas en el tablero.

<img width="1061" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/cc452448-9fec-459c-acec-b88ff8613aeb">
