### PR TITLE
Add acp and pacp fields to project and stage interfaces

### DIFF
--- a/packages/frontend/src/graphql/queries/project.ts
+++ b/packages/frontend/src/graphql/queries/project.ts
@@ -81,7 +81,9 @@ export const GET_PROJECTS_BY_AREA_AND_STATE = gql`
       cost
       startDate
       endDate
-
+      acp
+      pacp
+      
       state {
         id
         name
@@ -103,6 +105,8 @@ export const GET_PROJECTS_BY_AREA_AND_STATE = gql`
         startDate
         endDate
         progress
+        acp
+        pacp
       }
     }
   }

--- a/packages/frontend/src/sections/area/detalle/project-tab/project-line.tsx
+++ b/packages/frontend/src/sections/area/detalle/project-tab/project-line.tsx
@@ -4,6 +4,8 @@ import NextLink from 'next/link'
 import { Box, Typography, IconButton, Link } from '@mui/material'
 import Iconify from 'src/components/iconify/iconify'
 import { paths } from 'src/routes/paths'
+import { getColorFromAcp, getColorFromPacp } from 'src/utils/average-completition'
+import { DEFAULT_PERCENTAGE_ALERT_MARGIN } from 'src/constants'
 import StageSubLine from './stage-sub-line'
 import StageLine from './stage-line'
 
@@ -11,8 +13,16 @@ type TProps = {
   project: IProject
 }
 
+
 export default function ProjectLine(props: TProps) {
   const { project } = props
+
+  const colorFromAcpOrPacp = (proj: IProject) => {
+    if (proj.acp === null) {
+      return getColorFromPacp(proj.pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+    }
+    return getColorFromAcp(proj.acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+  }
 
   const [expanded, setExpanded] = useState(false)
 
@@ -62,7 +72,7 @@ export default function ProjectLine(props: TProps) {
           sx={{
             width: '100%',
             borderRadius: 2,
-            backgroundColor: 'primary.main',
+            backgroundColor: colorFromAcpOrPacp(project),
             height: 35,
             display: 'flex',
             flexDirection: 'row',

--- a/packages/frontend/src/sections/area/detalle/project-tab/project-line.tsx
+++ b/packages/frontend/src/sections/area/detalle/project-tab/project-line.tsx
@@ -13,16 +13,15 @@ type TProps = {
   project: IProject
 }
 
+const colorFromAcpOrPacp = (proj: IProject) => {
+  if (proj.acp === null) {
+    return getColorFromPacp(proj.pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+  }
+  return getColorFromAcp(proj.acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+}
 
 export default function ProjectLine(props: TProps) {
   const { project } = props
-
-  const colorFromAcpOrPacp = (proj: IProject) => {
-    if (proj.acp === null) {
-      return getColorFromPacp(proj.pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
-    }
-    return getColorFromAcp(proj.acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
-  }
 
   const [expanded, setExpanded] = useState(false)
 

--- a/packages/frontend/src/sections/area/detalle/project-tab/stage-line.tsx
+++ b/packages/frontend/src/sections/area/detalle/project-tab/stage-line.tsx
@@ -11,15 +11,15 @@ type TProps = {
   stage: IStage
 }
 
+const colorFromAcpOrPacp = (stag: IStage) => {
+  if (stag.acp === null) {
+    return getColorFromPacp(stag.pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+  }
+  return getColorFromAcp(stag.acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+}
+
 export default function StageLine(props: TProps) {
   const { stage } = props
-
-  const colorFromAcpOrPacp = (stag: IStage) => {
-    if (stag.acp === null) {
-      return getColorFromPacp(stag.pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
-    }
-    return getColorFromAcp(stag.acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
-  }
 
   return (
     <Box

--- a/packages/frontend/src/sections/area/detalle/project-tab/stage-line.tsx
+++ b/packages/frontend/src/sections/area/detalle/project-tab/stage-line.tsx
@@ -4,6 +4,8 @@ import NextLink from 'next/link'
 import { Box, IconButton, Typography, Link } from '@mui/material'
 import Iconify from 'src/components/iconify'
 import { paths } from 'src/routes/paths'
+import { getColorFromAcp, getColorFromPacp } from 'src/utils/average-completition'
+import { DEFAULT_PERCENTAGE_ALERT_MARGIN } from 'src/constants'
 
 type TProps = {
   stage: IStage
@@ -11,6 +13,13 @@ type TProps = {
 
 export default function StageLine(props: TProps) {
   const { stage } = props
+
+  const colorFromAcpOrPacp = (stag: IStage) => {
+    if (stag.acp === null) {
+      return getColorFromPacp(stag.pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+    }
+    return getColorFromAcp(stag.acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+  }
 
   return (
     <Box
@@ -59,7 +68,7 @@ export default function StageLine(props: TProps) {
         <Box
           sx={{
             width: `${stage.progress * 100}%`,
-            backgroundColor: 'primary.main',
+            backgroundColor: colorFromAcpOrPacp(stage),
             height: 35,
             borderRadius: 2,
             textAlign: 'center',

--- a/packages/shared/types/project.ts
+++ b/packages/shared/types/project.ts
@@ -16,6 +16,8 @@ export interface IProject {
   progress: number
   stateId: number
   areaId: number | null
+  acp: number | null
+  pacp: number | null
 
   createdAt: string
   updatedAt: string

--- a/packages/shared/types/stage.ts
+++ b/packages/shared/types/stage.ts
@@ -18,6 +18,8 @@ export interface IStage {
   areaId: number | null
   projectId: number
   parentStageId: number | null
+  acp: number | null
+  pacp: number | null
 
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
Los colores de proyectos y etapas en el tab de proyectos del tablero, ahora se obtienen desde el ACP o PACP.