### PR TITLE
Add multiline support to checklist title input

### DIFF
--- a/packages/frontend/src/layouts/_common/checklist-popover/checklist-create-modal.tsx
+++ b/packages/frontend/src/layouts/_common/checklist-popover/checklist-create-modal.tsx
@@ -133,6 +133,7 @@ export default function CreateChecklistModal(props: TProps) {
               label="Titulo"
               variant="standard"
               fullWidth
+              multiline
               value={formik.values.title}
               onChange={formik.handleChange}
               error={!!formik.errors.title}

--- a/packages/frontend/src/layouts/_common/checklist-popover/checklist-item.tsx
+++ b/packages/frontend/src/layouts/_common/checklist-popover/checklist-item.tsx
@@ -13,6 +13,8 @@ type TProps = {
   refetch: () => void
 }
 
+const MAX_CHARACTERS = 33
+
 export function ChecklistItem(props: TProps) {
   const { checklist, refetch } = props
   const { checks = [] } = checklist
@@ -34,7 +36,7 @@ export function ChecklistItem(props: TProps) {
         >
           <Box>
             <Typography variant="h6" sx={{ flexGrow: 1 }}>
-              {checklist.title}
+              {checklist.title.length > MAX_CHARACTERS ? `${checklist.title.slice(0, MAX_CHARACTERS)}...` : checklist.title}
             </Typography>
             <Stack
               direction="row"

--- a/packages/frontend/src/layouts/_common/checklist-popover/checklist-update-modal.tsx
+++ b/packages/frontend/src/layouts/_common/checklist-popover/checklist-update-modal.tsx
@@ -153,6 +153,7 @@ export default function CreateChecklistModal(props: TProps) {
               label="Titulo"
               variant="standard"
               fullWidth
+              multiline
               value={formik.values.title}
               onChange={formik.handleChange}
               error={!!formik.errors.title}


### PR DESCRIPTION
Se ajusta la cantidad máxima de caracteres en el checklist.
También se agrega multiline al modal de creacion y update del titulo del checklist

<img width="409" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/6a7d030f-62f8-47c6-9146-fc19a23e0151">
