### PR TITLE
Remove switch component from checklist create and update modal

### DIFF
--- a/packages/backend/src/graphql/checklist/resolvers.ts
+++ b/packages/backend/src/graphql/checklist/resolvers.ts
@@ -120,7 +120,7 @@ export default {
   Mutation: {
     createChecklist: async (
       _: any,
-      args: Pick<IChecklist, 'title' | 'stageId' | 'projectId' | 'remember'> & {
+      args: Pick<IChecklist, 'title' | 'stageId' | 'projectId'> & {
         checks: Pick<ICheck, 'title' | 'checked'>[]
       },
       context: IContext
@@ -149,14 +149,14 @@ export default {
     },
     updateChecklist: async (
       _: any,
-      args: Pick<IChecklist, 'id' | 'title' | 'stageId' | 'projectId' | 'remember'> & {
+      args: Pick<IChecklist, 'id' | 'title' | 'stageId' | 'projectId'> & {
         checks: Pick<ICheck, 'title' | 'checked'>[]
       },
       context: IContext
     ): Promise<Omit<IChecklist, 'checks' | 'user' | 'stage' | 'project'>> => {
       try {
         needPermission([PERMISSION_MAP.CHECKLIST_UPDATE], context)
-        const { id, title, stageId, projectId, checks, remember } = args
+        const { id, title, stageId, projectId, checks } = args
         const { user } = context
         if (!user) throw new Error('No autorizado')
         const checklist = await Checklist.findOne({
@@ -171,7 +171,6 @@ export default {
           stageId,
           projectId,
           finished: checks.every((check) => check.checked),
-          remember,
         })
         await Check.destroy({
           where: {

--- a/packages/backend/src/graphql/checklist/resolvers.ts
+++ b/packages/backend/src/graphql/checklist/resolvers.ts
@@ -127,7 +127,7 @@ export default {
     ): Promise<Omit<IChecklist, 'checks' | 'user' | 'stage' | 'project'>> => {
       try {
         needPermission([PERMISSION_MAP.CHECKLIST_CREATE], context)
-        const { title, stageId, projectId, checks, remember } = args
+        const { title, stageId, projectId, checks } = args
         const { user } = context
         if (!user) throw new Error('No autorizado')
         const checklist = await Checklist.create({
@@ -136,7 +136,6 @@ export default {
           stageId,
           projectId,
           finished: checks.every((check) => check.checked),
-          remember,
         })
         await Promise.all(
           checks.map((check) => Check.create({ ...check, checklistId: checklist.id }))

--- a/packages/backend/src/graphql/checklist/type-defs.ts
+++ b/packages/backend/src/graphql/checklist/type-defs.ts
@@ -40,7 +40,6 @@ export default `#graphql
     updateChecklist(
       id: Int!
       title: String
-      remember: Boolean!
       stageId: Int
       projectId: Int
       checks: [CheckInput]

--- a/packages/backend/src/graphql/checklist/type-defs.ts
+++ b/packages/backend/src/graphql/checklist/type-defs.ts
@@ -32,7 +32,6 @@ export default `#graphql
   type Mutation {
     createChecklist(
       title: String!
-      remember: Boolean!
       stageId: Int
       projectId: Int
       checks: [CheckInput]

--- a/packages/frontend/src/graphql/mutations/checklist.ts
+++ b/packages/frontend/src/graphql/mutations/checklist.ts
@@ -22,7 +22,6 @@ export const UPDATE_CHECKLIST = gql`
   mutation updateChecklist(
     $id: Int!
     $title: String
-    $remember: Boolean!
     $stageId: Int
     $projectId: Int
     $checks: [CheckInput]
@@ -30,7 +29,6 @@ export const UPDATE_CHECKLIST = gql`
     updateChecklist(
       id: $id
       title: $title
-      remember: $remember
       stageId: $stageId
       projectId: $projectId
       checks: $checks

--- a/packages/frontend/src/graphql/mutations/checklist.ts
+++ b/packages/frontend/src/graphql/mutations/checklist.ts
@@ -3,14 +3,12 @@ import { gql } from '@apollo/client'
 export const CREATE_CHECKLIST = gql`
   mutation createChecklist(
     $title: String!
-    $remember: Boolean!
     $stageId: Int
     $projectId: Int
     $checks: [CheckInput]
   ) {
     createChecklist(
       title: $title
-      remember: $remember
       stageId: $stageId
       projectId: $projectId
       checks: $checks

--- a/packages/frontend/src/layouts/_common/checklist-popover/checklist-create-modal.tsx
+++ b/packages/frontend/src/layouts/_common/checklist-popover/checklist-create-modal.tsx
@@ -14,7 +14,6 @@ import {
   Checkbox,
   Stack,
   Tooltip,
-  Switch,
 } from '@mui/material'
 import Iconify from 'src/components/iconify'
 import Scrollbar from 'src/components/scrollbar'
@@ -121,10 +120,6 @@ export default function CreateChecklistModal(props: TProps) {
     formik.setFieldValue('checks', newChecks)
   }
 
-  const handleChangeSwitchAlert = () => {
-    formik.setFieldValue('remember', !formik.values.remember)
-  }
-
   return (
     <Modal
       open={modal.value}
@@ -211,20 +206,6 @@ export default function CreateChecklistModal(props: TProps) {
                 gap: 1,
               }}
             >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                }}
-              >
-                <Switch
-                  checked={formik.values.remember}
-                  onChange={handleChangeSwitchAlert}
-                  name="remember"
-                />
-                <Typography>Activar alerta</Typography>
-              </Box>
               <Box
                 sx={{
                   display: 'flex',

--- a/packages/frontend/src/layouts/_common/checklist-popover/checklist-update-modal.tsx
+++ b/packages/frontend/src/layouts/_common/checklist-popover/checklist-update-modal.tsx
@@ -14,7 +14,6 @@ import {
   Checkbox,
   Stack,
   Tooltip,
-  Switch,
 } from '@mui/material'
 import Iconify from 'src/components/iconify'
 import Scrollbar from 'src/components/scrollbar'
@@ -142,10 +141,6 @@ export default function CreateChecklistModal(props: TProps) {
     formik.setFieldValue('checks', newChecks)
   }
 
-  const handleChangeSwitchAlert = () => {
-    formik.setFieldValue('remember', !formik.values.remember)
-  }
-
   return (
     <Modal
       open={modal.value}
@@ -225,20 +220,6 @@ export default function CreateChecklistModal(props: TProps) {
                 gap: 1,
               }}
             >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                }}
-              >
-                <Switch
-                  checked={formik.values.remember}
-                  onChange={handleChangeSwitchAlert}
-                  name="remember"
-                />
-                <Typography>Activar alerta</Typography>
-              </Box>
               <Box
                 sx={{
                   display: 'flex',


### PR DESCRIPTION
Se quita el switch para recordar notificar el checklist desde el modal de creación y actualización,