### PR TITLE
Add tooltip to AssignmentItem component

### DIFF
--- a/packages/frontend/src/sections/tablero/assignment-tab/assignment-item.tsx
+++ b/packages/frontend/src/sections/tablero/assignment-tab/assignment-item.tsx
@@ -7,7 +7,12 @@ import { fDate } from 'src/utils/format-time'
 import Label from 'src/components/label'
 import Iconify from 'src/components/iconify'
 import TextMaxLine from 'src/components/text-max-line'
-import { getColorFromAcp, getColorFromPacp } from 'src/utils/average-completition'
+import {
+  getColorFromAcp,
+  getColorFromPacp,
+  getTooltipFromAcp,
+  getTooltipFromPacp,
+} from 'src/utils/average-completition'
 import { DEFAULT_PERCENTAGE_ALERT_MARGIN } from 'src/constants'
 import getLabelColor from 'src/utils/color-progress'
 
@@ -24,6 +29,13 @@ const colorFromAcpOrPacp = (acp: number | null, pacp: number | null) => {
     return getColorFromPacp(pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
   }
   return getColorFromAcp(acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+}
+
+const getTootipFromAcpOrPacp = (acp: number | null, pacp: number | null) => {
+  if (acp === null) {
+    return getTooltipFromPacp(pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+  }
+  return getTooltipFromAcp(acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
 }
 
 export default function AssignmentItem(props: TProps) {
@@ -128,18 +140,22 @@ export default function AssignmentItem(props: TProps) {
               color: 'text.disabled',
             }}
           >
-            <div
-              style={{
-                backgroundColor: colorFromAcpOrPacp(
-                  assignment.acp ?? null,
-                  assignment.pacp ?? null
-                ),
-                width: '15px',
-                height: '15px',
-                borderRadius: '50%',
-                marginRight: '5px',
-              }}
-            />
+            <Tooltip
+              title={getTootipFromAcpOrPacp(assignment.acp ?? null, assignment.pacp ?? null)}
+            >
+              <Box
+                sx={{
+                  backgroundColor: colorFromAcpOrPacp(
+                    assignment.acp ?? null,
+                    assignment.pacp ?? null
+                  ),
+                  width: 15,
+                  height: 15,
+                  borderRadius: '50%',
+                  marginRight: 1,
+                }}
+              />
+            </Tooltip>
             {progress * 100}%
           </Stack>
           <Stack


### PR DESCRIPTION
Se agrega el tooltip en el campo de acp o pacp de las tarjetas de asignacion.

<img width="415" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/5af621c3-5fb8-4a1f-90b7-29a19c7aa2bd">
