### PR TITLE
Adp 243

### DIFF
--- a/packages/frontend/src/graphql/queries/stage.ts
+++ b/packages/frontend/src/graphql/queries/stage.ts
@@ -12,6 +12,8 @@ export const GET_STAGES_BY_PROJECT = gql`
       hasStages
       projectId
       stateId
+      acp
+      pacp
       area {
         id
         name
@@ -40,6 +42,8 @@ export const GET_SUB_STAGES_BY_STAGE = gql`
       hasStages
       projectId
       stateId
+      acp
+      pacp
       area {
         id
         name

--- a/packages/frontend/src/sections/area/detalle/stadistic-tab/filter-component.tsx
+++ b/packages/frontend/src/sections/area/detalle/stadistic-tab/filter-component.tsx
@@ -1,11 +1,9 @@
-
 import React from 'react'
 import { useDashboardReportContext } from 'src/contexts/dashboard-report-context'
 import { Box, Grid, Card } from '@mui/material'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 
 export default function FilterComponent() {
-
   const {
     selectedInitialDate,
     selectedFinalDate,

--- a/packages/frontend/src/sections/project/detalle/stages-tab/kanban/view/kanban-task-item.tsx
+++ b/packages/frontend/src/sections/project/detalle/stages-tab/kanban/view/kanban-task-item.tsx
@@ -70,7 +70,7 @@ export default function KanbanTaskItem({ project, task, sx, refetch, ...other }:
               <Tooltip title="Tiene subetapas">
                 <Iconify icon="clarity:folder-line" width={16} sx={{ color: 'text.disabled' }} />
               </Tooltip>
-            )}            
+            )}
           </Stack>
 
           <Box

--- a/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-task-item.tsx
+++ b/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-task-item.tsx
@@ -1,11 +1,17 @@
 import { IStage } from '@adp/shared'
 import React from 'react'
-import { Stack, Box, Avatar, PaperProps, Paper, Typography } from '@mui/material'
+import { Stack, Box, PaperProps, Paper, Typography, Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { useBoolean } from 'src/hooks/use-boolean'
+import {
+  getColorFromAcp,
+  getColorFromPacp,
+  getTooltipFromAcp,
+  getTooltipFromPacp,
+} from 'src/utils/average-completition'
+import { DEFAULT_PERCENTAGE_ALERT_MARGIN } from 'src/constants'
+import { fDate } from 'src/utils/format-time'
 import Iconify from 'src/components/iconify'
-import { ERROR, INFO, WARNING } from 'src/theme/palette'
-import { getStorageFileUrl } from 'src/utils/storage'
 import KanbanDetails from './kanban-details'
 
 // ----------------------------------------------------------------------
@@ -16,14 +22,18 @@ type Props = PaperProps & {
   refetch: () => void
 }
 
-const getColor = (progress: number) => {
-  if (progress >= 0.6) {
-    return INFO.main
+const colorFromAcpOrPacp = (acp: number | null, pacp: number | null) => {
+  if (acp === null) {
+    return getColorFromPacp(pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
   }
-  if (progress > 0.3 && progress <= 0.6) {
-    return WARNING.main
+  return getColorFromAcp(acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+}
+
+const getTootipFromAcpOrPacp = (acp: number | null, pacp: number | null) => {
+  if (acp === null) {
+    return getTooltipFromPacp(pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
   }
-  return ERROR.main
+  return getTooltipFromAcp(acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
 }
 
 export default function KanbansubStageItemItem({
@@ -34,8 +44,6 @@ export default function KanbansubStageItemItem({
   ...other
 }: Props) {
   const theme = useTheme()
-
-  const color = getColor(subStageItem.progress)
 
   const openDetails = useBoolean()
 
@@ -61,47 +69,79 @@ export default function KanbansubStageItemItem({
         }}
         {...other}
       >
-        <Stack spacing={2} sx={{ px: 2, py: 2.5, position: 'relative' }}>
-          <Typography variant="subtitle2">{subStageItem.name}</Typography>
-
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <Typography variant="subtitle2">
-              {subStageItem.responsible?.fullname || 'Sin asignar'}
-            </Typography>
-            <Avatar
-              src={
-                subStageItem.responsible
-                  ? getStorageFileUrl(subStageItem.responsible.image, '/broken-image.jpg')
-                  : '/broken-image.jpg'
+        <Stack spacing={2} sx={{ px: 2, py: 2, position: 'relative', minWidth: 280 }}>
+            <Typography variant="subtitle2">{subStageItem.name}</Typography>
+          <Box
+            sx={{
+              mt: -2,
+              mb: -1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Stack
+              direction="row"
+              alignItems="center"
+              sx={{ typography: 'caption', color: 'text.disabled' }}
+              divider={
+                <Box
+                  sx={{
+                    width: 2,
+                    height: 2,
+                    bgcolor: 'currentColor',
+                    mx: 0.5,
+                    borderRadius: '50%',
+                  }}
+                />
               }
-              sx={{ width: 35, height: 35, border: `solid 2px ${color}` }}
-            />
+            >
+              {subStageItem.area?.name || 'Sin area'}
+              {subStageItem.responsible?.fullname || 'Sin asignar'}
+            </Stack>
           </Box>
 
-          <Iconify
-            icon={
-              (subStageItem.progress <= 0.3 && 'solar:double-alt-arrow-down-bold-duotone') ||
-              (subStageItem.progress > 0.3 &&
-                subStageItem.progress <= 0.6 &&
-                'solar:double-alt-arrow-right-bold-duotone') ||
-              'solar:double-alt-arrow-up-bold-duotone'
-            }
-            sx={{
-              position: 'absolute',
-              top: 4,
-              right: 4,
-              ...(subStageItem.progress >= 0.6 && {
-                color: 'info.main',
-              }),
-              ...(subStageItem.progress > 0.3 &&
-                subStageItem.progress <= 0.6 && {
-                  color: 'warning.main',
-                }),
-              ...(subStageItem.progress <= 0.3 && {
-                color: 'error.main',
-              }),
-            }}
-          />
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Stack
+              direction="row"
+              alignItems="center"
+              sx={{
+                typography: 'caption',
+                color: 'text.disabled',
+              }}
+            >
+              <Tooltip title={getTootipFromAcpOrPacp(subStageItem.acp ?? null, subStageItem.pacp ?? null)}>
+                <Box
+                  sx={{
+                    backgroundColor: colorFromAcpOrPacp(subStageItem.acp ?? null, subStageItem.pacp ?? null),
+                    width: 15,
+                    height: 15,
+                    borderRadius: '50%',
+                    marginRight: 1,
+                  }}
+                />
+              </Tooltip>
+              {subStageItem.progress * 100}%
+            </Stack>
+            <Stack
+              spacing={1.5}
+              flexGrow={1}
+              direction="row"
+              flexWrap="wrap"
+              justifyContent="flex-end"
+              sx={{
+                typography: 'caption',
+                color: 'text.disabled',
+              }}
+            >
+              <Stack direction="row" alignItems="center">
+                <Iconify icon="clarity:date-line" width={16} sx={{ mr: 1 }} />
+                <Stack alignItems="center">
+                  {fDate(new Date(subStageItem.startDate))} - {fDate(new Date(subStageItem.endDate))}
+                </Stack>
+              </Stack>
+            </Stack>
+          </Stack>
         </Stack>
       </Paper>
       {openDetails.value && (

--- a/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-task-item.tsx
+++ b/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-task-item.tsx
@@ -70,7 +70,7 @@ export default function KanbansubStageItemItem({
         {...other}
       >
         <Stack spacing={2} sx={{ px: 2, py: 2, position: 'relative', minWidth: 280 }}>
-            <Typography variant="subtitle2">{subStageItem.name}</Typography>
+          <Typography variant="subtitle2">{subStageItem.name}</Typography>
           <Box
             sx={{
               mt: -2,
@@ -110,10 +110,15 @@ export default function KanbansubStageItemItem({
                 color: 'text.disabled',
               }}
             >
-              <Tooltip title={getTootipFromAcpOrPacp(subStageItem.acp ?? null, subStageItem.pacp ?? null)}>
+              <Tooltip
+                title={getTootipFromAcpOrPacp(subStageItem.acp ?? null, subStageItem.pacp ?? null)}
+              >
                 <Box
                   sx={{
-                    backgroundColor: colorFromAcpOrPacp(subStageItem.acp ?? null, subStageItem.pacp ?? null),
+                    backgroundColor: colorFromAcpOrPacp(
+                      subStageItem.acp ?? null,
+                      subStageItem.pacp ?? null
+                    ),
                     width: 15,
                     height: 15,
                     borderRadius: '50%',
@@ -137,7 +142,8 @@ export default function KanbansubStageItemItem({
               <Stack direction="row" alignItems="center">
                 <Iconify icon="clarity:date-line" width={16} sx={{ mr: 1 }} />
                 <Stack alignItems="center">
-                  {fDate(new Date(subStageItem.startDate))} - {fDate(new Date(subStageItem.endDate))}
+                  {fDate(new Date(subStageItem.startDate))} -{' '}
+                  {fDate(new Date(subStageItem.endDate))}
                 </Stack>
               </Stack>
             </Stack>


### PR DESCRIPTION
Se cambia el diseño de las tarjetas en el kanvan de etapas y subetapas, llevándolo a un diseño parecido como las tarjetas de asignaciones.

<img width="1035" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/838abca0-7617-429f-bbc6-3f096fb7c35c">