### PR TITLE
Adp 252

### DIFF
--- a/packages/frontend/src/layouts/_common/notifications-popover/notification-item.tsx
+++ b/packages/frontend/src/layouts/_common/notifications-popover/notification-item.tsx
@@ -72,7 +72,6 @@ export default function NotificationItem({
         p: 2.5,
         display: 'flex',
         alignItems: 'flex-start',
-        justifyContent: 'space-between',
         borderBottom: (theme) => `dashed 1px ${theme.palette.divider}`,
         ...(checked && {
           bgcolor: (theme) => theme.palette.primary.lighter,
@@ -103,7 +102,7 @@ export default function NotificationItem({
 
       {renderUnReadBadge}
 
-      <Stack sx={{ flexGrow: 1 }}>{renderText}</Stack>
+      <Stack sx={{ flexGrow: 1, maxWidth: 310 }}>{renderText}</Stack>
     </ListItemButton>
   )
 }

--- a/packages/frontend/src/sections/area/detalle/stadistic-tab/filter-component.tsx
+++ b/packages/frontend/src/sections/area/detalle/stadistic-tab/filter-component.tsx
@@ -1,11 +1,9 @@
-
 import React from 'react'
 import { useDashboardReportContext } from 'src/contexts/dashboard-report-context'
 import { Box, Grid, Card } from '@mui/material'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 
 export default function FilterComponent() {
-
   const {
     selectedInitialDate,
     selectedFinalDate,


### PR DESCRIPTION
Se ajusta el ancho del mensaje en el modal de notificaciones para que no se superponga con el badge de no leido.

<img width="410" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/8e401d25-c864-4e81-a5ca-d472944b21d8">
