### PR TITLE
ADP-267

### DIFF
--- a/packages/backend/src/graphql/stage/resolvers.ts
+++ b/packages/backend/src/graphql/stage/resolvers.ts
@@ -355,7 +355,7 @@ export default {
         needPermission([PERMISSION_MAP.PROJECT_READ], context)
         const { name, description, startDate, endDate, areaId, projectId, parentStageId } = args
 
-        const actualDate = new Date().toISOString().slice(0, 10)
+        const today = new Date(new Date().getTime() - 1000 * 60 * 60 * 3).toISOString().slice(0, 10)
         const start = new Date(startDate).toISOString().slice(0, 10)
         const end = new Date(endDate).toISOString().slice(0, 10)
         if (start > end)
@@ -366,7 +366,7 @@ export default {
         const projectStart = new Date(project.startDate).toISOString().slice(0, 10)
         const projectEnd = new Date(project.endDate).toISOString().slice(0, 10)
         if (start < projectStart || end > projectEnd) throw new Error('Fecha fuera de rango')
-        const state = start > actualDate ? TASK_STATE.NEW : TASK_STATE.IN_PROGRESS
+        const stateId = start > today ? TASK_STATE.NEW : TASK_STATE.IN_PROGRESS
 
         const { acp, pacp } = getAcp({ startDate, endDate, finishedAt: null })
         const stageCreated = await Stage.create({
@@ -374,7 +374,7 @@ export default {
           description,
           startDate,
           endDate,
-          stateId: state,
+          stateId,
           areaId,
           projectId,
           parentStageId,
@@ -649,7 +649,7 @@ export default {
         needPermission([PERMISSION_MAP.PROJECT_READ], context)
         const { name, description, startDate, endDate, areaId, parentStageId } = args
 
-        const actualDate = new Date().toISOString().slice(0, 10)
+        const today = new Date(new Date().getTime() - 1000 * 60 * 60 * 3).toISOString().slice(0, 10)
         const start = new Date(startDate).toISOString().slice(0, 10)
         const end = new Date(endDate).toISOString().slice(0, 10)
         if (start > end)
@@ -662,7 +662,7 @@ export default {
 
         if (start < parentStageStart || end > parentStageEnd)
           throw new Error('Fechas fuera de rango')
-        const state = start > actualDate ? TASK_STATE.NEW : TASK_STATE.IN_PROGRESS
+        const stateId = start > today ? TASK_STATE.NEW : TASK_STATE.IN_PROGRESS
 
         const { acp, pacp } = getAcp({ startDate, endDate, finishedAt: null })
         const stageCreated = await Stage.create({
@@ -670,7 +670,7 @@ export default {
           description,
           startDate,
           endDate,
-          stateId: state,
+          stateId,
           areaId,
           projectId: parentStage.projectId,
           parentStageId,


### PR DESCRIPTION
Se ajusta el problema que al crear una etapa o subetapa después de las 21hs y antes de las 24hs, no se cambiaba el estado si correspondía.