### PR TITLE
ADP-291

### DIFF
--- a/packages/frontend/src/sections/project/detalle/view.tsx
+++ b/packages/frontend/src/sections/project/detalle/view.tsx
@@ -225,7 +225,7 @@ export default function ProjectDetailView(props: TProps) {
                       label="Progreso"
                       variant="outlined"
                       fullWidth
-                      value={`${(project.progress * 100).toFixed(2)}`}
+                      value={`${(project.progress * 100).toFixed(0)}`}
                       InputProps={{
                         startAdornment: (
                           <InputAdornment position="start">

--- a/packages/frontend/src/sections/stage/detail/view.tsx
+++ b/packages/frontend/src/sections/stage/detail/view.tsx
@@ -210,7 +210,7 @@ export default function ProjectDetailView(props: TProps) {
                       label="Progreso"
                       variant="outlined"
                       fullWidth
-                      value={`${(stage.progress * 100).toFixed(2)}`}
+                      value={`${(stage.progress * 100).toFixed(0)}`}
                       InputProps={{
                         startAdornment: (
                           <InputAdornment position="start">

--- a/packages/frontend/src/sections/tablero/assignment-tab/assignment-item.tsx
+++ b/packages/frontend/src/sections/tablero/assignment-tab/assignment-item.tsx
@@ -156,7 +156,7 @@ export default function AssignmentItem(props: TProps) {
                 }}
               />
             </Tooltip>
-            {progress * 100}%
+            {(progress * 100).toFixed(0)}%
           </Stack>
           <Stack
             spacing={1.5}


### PR DESCRIPTION
Se ajusta la visualización del progreso, en todos lados se muestra el porcentaje sin decimales, por eso se ajusto el resto que se fixeaba a 2 decimales, a cero decimales.