### PR TITLE
ADP-278

### DIFF
--- a/packages/frontend/src/sections/project/detalle/view.tsx
+++ b/packages/frontend/src/sections/project/detalle/view.tsx
@@ -14,6 +14,7 @@ import {
   InputAdornment,
   Button,
   Tooltip,
+  Alert
 } from '@mui/material'
 import { useSettingsContext } from 'src/components/settings'
 import { paths } from 'src/routes/paths'
@@ -34,6 +35,7 @@ import {
 } from 'src/utils/average-completition'
 import { DEFAULT_PERCENTAGE_ALERT_MARGIN } from 'src/constants'
 import { formatCost } from 'src/utils/format-number'
+import { SUCCESS, WARNING, ERROR } from 'src/theme/palette';
 import StagesTab from './stages-tab'
 import GanttTab from './gantt-tab'
 import NotesTab from './notes-tab'
@@ -64,6 +66,20 @@ const getTootipFromAcpOrPacp = (acp: number | null, pacp: number | null) => {
     return getTooltipFromPacp(pacp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
   }
   return getTooltipFromAcp(acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+}
+
+const getSeverityFromAcp = (acp: number | null) => {
+  const severity = getColorFromAcp(acp, DEFAULT_PERCENTAGE_ALERT_MARGIN)
+  switch (severity) {
+    case SUCCESS.main:
+      return 'success'
+    case WARNING.main:
+      return 'warning'
+    case ERROR.main:
+      return 'error'
+    default:
+      return 'info'
+  }
 }
 
 export default function ProjectDetailView(props: TProps) {
@@ -151,6 +167,11 @@ export default function ProjectDetailView(props: TProps) {
 
         {!!project && (
           <React.Fragment>
+            {project.stateId === TASK_STATE.COMPLETED && (
+              <Alert severity={getSeverityFromAcp(project.acp ?? null)}>
+                El proyecto fue finalizado en la fecha: {formatDate(project.endDate)}
+              </Alert>
+            )}
             <Card>
               <CardContent>
                 <Grid container spacing={2}>


### PR DESCRIPTION
Se agrega un alert en el detalle del proyecto que indica la fecha de finalización con el color de fondo del ACP, siempre y cuando haya terminado el proyecto.

<img width="1116" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/0737fc68-712f-4003-8895-246ebb8f39ce">
