### PR TITLE
ADP-295

### DIFF
--- a/packages/backend/src/graphql/stage/resolvers.ts
+++ b/packages/backend/src/graphql/stage/resolvers.ts
@@ -216,7 +216,10 @@ export default {
               as: 'state',
             },
           ],
-          order: [['startDate', 'ASC']],
+          order: [
+            ['startDate', 'ASC'],
+            ['createdAt', 'ASC'],
+          ],
         }) as unknown as Promise<Omit<IStage, 'parentStage' | 'childStages' | 'project'>[]>
       } catch (error) {
         logger.error(error)


### PR DESCRIPTION
Las subetapas se reciben ordenadas por fecha de inicio y por fecha de creación, en ese orden,