### PR TITLE
ADP-306

### DIFF
--- a/packages/frontend/src/layouts/_common/notifications-popover/notification-item.tsx
+++ b/packages/frontend/src/layouts/_common/notifications-popover/notification-item.tsx
@@ -1,7 +1,7 @@
 import { INotification } from '@adp/shared'
-import { Box, Stack, ListItemText, ListItemButton } from '@mui/material'
+import { Box, Stack, ListItemText, ListItemButton, Tooltip } from '@mui/material'
 import Iconify from 'src/components/iconify'
-import { fToNow } from 'src/utils/format-time'
+import { fDate, fToNow } from 'src/utils/format-time'
 import { useSettingsContext } from 'src/components/settings'
 
 type NotificationItemProps = {
@@ -52,7 +52,11 @@ export default function NotificationItem({
             />
           }
         >
-          {fToNow(Number(notification.createdAt))}
+          <Tooltip title={`${fDate(Number(notification.createdAt))} - ${new Date(Number(notification.createdAt)).toLocaleTimeString()}`}>
+            <Box>
+              {fToNow(Number(notification.createdAt))}
+            </Box>
+          </Tooltip>
           {notification.category}
         </Stack>
       }

--- a/packages/frontend/src/sections/shared/note-item.tsx
+++ b/packages/frontend/src/sections/shared/note-item.tsx
@@ -10,7 +10,7 @@ import {
   CardContent,
   Tooltip,
 } from '@mui/material'
-import { fDate } from 'src/utils/format-time'
+import { fDate, fToNow} from 'src/utils/format-time'
 import Iconify from 'src/components/iconify'
 import { IProjectNote, IStageNote } from '@adp/shared'
 import { getStorageFileUrl } from 'src/utils/storage'
@@ -48,8 +48,12 @@ export default function NoteItem(props: TProps) {
         }
         subheader={
           <Box sx={{ color: 'text.disabled', typography: 'caption', mt: 0.5 }}>
-            {fDate(new Date(Number(note.createdAt)))} -{' '}
-            {new Date(Number(note.createdAt)).toLocaleTimeString()}
+            <Tooltip title={`${fDate(Number(note.createdAt))} - ${new Date(Number(note.createdAt)).toLocaleTimeString()}`}>
+              <Typography variant="caption">
+                {fToNow(Number(note.createdAt))}
+              </Typography>
+            </Tooltip>
+            
           </Box>
         }
         action={


### PR DESCRIPTION
Tanto las notas como las notificaciones tienen el mismo tipo de visualización de la fecha, junto con un tooltip.

<img width="377" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/168d34b2-dbc6-4d63-bc21-3b56de39d200">

<img width="416" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/b6fa598f-9deb-4db7-bb34-b15091074d45">
