### PR TITLE
ADP-297

### DIFF
--- a/packages/frontend/src/graphql/queries/stage.ts
+++ b/packages/frontend/src/graphql/queries/stage.ts
@@ -160,6 +160,12 @@ export const GET_SUB_STAGE = gql`
           fullname
           image
         }
+        files {
+          id
+          originalName
+          filename
+          size
+        }
       }
     }
   }

--- a/packages/frontend/src/graphql/queries/stage.ts
+++ b/packages/frontend/src/graphql/queries/stage.ts
@@ -102,6 +102,12 @@ export const GET_STAGE = gql`
           fullname
           image
         }
+        files {
+          id
+          originalName
+          filename
+          size
+        }
       }
     }
   }

--- a/packages/frontend/src/sections/project/detalle/stages-tab/kanban/view/kanban-details-comment-input.tsx
+++ b/packages/frontend/src/sections/project/detalle/stages-tab/kanban/view/kanban-details-comment-input.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Button from '@mui/material/Button'
@@ -12,6 +12,9 @@ import { useAuthContext } from 'src/auth/hooks'
 import { useSnackbar } from 'src/components/snackbar'
 import { CREATE_STAGE_NOTE } from 'src/graphql/mutations'
 import { getStorageFileUrl } from 'src/utils/storage'
+import { Typography } from '@mui/material'
+import AttachFileModal from 'src/sections/shared/attach-file-modal'
+import { useBoolean } from 'src/hooks/use-boolean'
 
 type TProps = {
   stageId: number
@@ -20,6 +23,7 @@ type TProps = {
 
 export default function KanbanDetailsCommentInput(props: TProps) {
   const { stageId, refetch } = props
+  const attachFileModal = useBoolean()
   const { user } = useAuthContext()
   const [createStageNote, { loading }] = useMutation(CREATE_STAGE_NOTE)
   const { enqueueSnackbar } = useSnackbar()
@@ -27,13 +31,14 @@ export default function KanbanDetailsCommentInput(props: TProps) {
   const formik = useFormik({
     initialValues: {
       message: '',
+      files: [],
     },
     onSubmit: (values, { resetForm }) => {
       createStageNote({
         variables: {
           message: values.message,
           stageId,
-          files: [],
+          files: values.files,
         },
       })
         .then(() => {
@@ -50,6 +55,18 @@ export default function KanbanDetailsCommentInput(props: TProps) {
         })
     },
   })
+
+  const isDisabled = useMemo(
+    () =>
+      (formik.values.message.length === 0 && formik.values.files.length === 0) ||
+      formik.isSubmitting,
+    [formik.isSubmitting, formik.values]
+  )
+
+  const handleAttachFile = (files: any[]) => {
+    formik.setFieldValue('files', files)
+    attachFileModal.onFalse()
+  }
 
   return (
     <Stack
@@ -83,16 +100,28 @@ export default function KanbanDetailsCommentInput(props: TProps) {
 
         <Stack direction="row" alignItems="center">
           <Stack direction="row" flexGrow={1}>
-            <IconButton disabled>
+            <IconButton onClick={attachFileModal.onTrue}>
               <Iconify icon="eva:attach-2-fill" />
             </IconButton>
+            <Typography variant="body2" sx={{ color: 'text.disabled' }}>
+              {formik.values.files.length === 0 && 'No hay archivos adjuntos'}
+              {formik.values.files.length === 1 && '1 archivo adjunto'}
+              {formik.values.files.length > 1 && `${formik.values.files.length} archivos adjuntos`}
+            </Typography>
           </Stack>
 
-          <Button variant="contained" onClick={() => formik.handleSubmit()} disabled={loading}>
-            Comentar
+          <Button variant="contained" onClick={() => formik.handleSubmit()} disabled={isDisabled}>
+            {formik.isSubmitting ? 'Publicando...' : 'Publicar'}
           </Button>
         </Stack>
       </Paper>
+      {attachFileModal.value && (
+        <AttachFileModal
+          files={formik.values.files}
+          modal={attachFileModal}
+          onSuccess={handleAttachFile}
+        />
+      )}
     </Stack>
   )
 }

--- a/packages/frontend/src/sections/project/detalle/stages-tab/kanban/view/kanban-details-comment-list.tsx
+++ b/packages/frontend/src/sections/project/detalle/stages-tab/kanban/view/kanban-details-comment-list.tsx
@@ -3,8 +3,11 @@ import React, { useMemo } from 'react'
 import Stack from '@mui/material/Stack'
 import Avatar from '@mui/material/Avatar'
 import Typography from '@mui/material/Typography'
-import { fToNow } from 'src/utils/format-time'
+import { fDate, fToNow } from 'src/utils/format-time'
 import { getStorageFileUrl } from 'src/utils/storage'
+import { Box, Card, Tooltip, Link } from '@mui/material'
+import { fShortenFileSize } from 'src/utils/format-number'
+import FileThumbnail from 'src/components/file-thumbnail/file-thumbnail'
 
 type TProps = {
   notes: IStageNote[]
@@ -45,11 +48,60 @@ export default function KanbanDetailsCommentList(props: TProps) {
               <Typography variant="subtitle2">
                 {note.user ? note.user.fullname : 'No asignado'}
               </Typography>
-              <Typography variant="caption" sx={{ color: 'text.disabled' }}>
-                {fToNow(Number(note.createdAt))}
-              </Typography>
+              <Tooltip title={`${fDate(new Date(Number(note.createdAt) - 3*60*60*1000))} - ${new Date(Number(note.createdAt)).toLocaleTimeString()}`}>
+                <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                  {fToNow(Number(note.createdAt))}
+                </Typography>
+              </Tooltip>
             </Stack>
             <Typography variant="body2">{note.message}</Typography>
+            {note.files && note.files.length > 0 && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: 2,
+                }}
+              >
+                {note.files.map((file) => (
+                  <Box
+                    key={file.id}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <Tooltip title={file.originalName} placement="top">
+                      <Link
+                        href={getStorageFileUrl(file.filename)}
+                        download={file.originalName}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{ textDecoration: 'none' }}
+                      >
+                        <Card
+                          sx={{
+                            p: 1,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <FileThumbnail file="doc" sx={{ width: 36, height: 36 }} />
+                          <Typography
+                            variant="body2"
+                            sx={{ fontSize: '10px', fontWeight: 'bold', color: 'text.disabled' }}
+                          >
+                            {fShortenFileSize(file.size)}
+                          </Typography>
+                        </Card>
+                      </Link>
+                    </Tooltip>
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Stack>
         </Stack>
       ))}

--- a/packages/frontend/src/sections/shared/attach-file-modal.tsx
+++ b/packages/frontend/src/sections/shared/attach-file-modal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react'
 import { useBoolean } from 'src/hooks/use-boolean'
 import { Dialog, Button, DialogTitle, DialogContent, DialogActions } from '@mui/material'
 import Iconify from 'src/components/iconify'
-import { Upload } from 'src/components/upload'
+import Upload from 'src/components/upload/upload'
 
 type TProps = {
   onSuccess: (files: any[]) => void

--- a/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-details-comment-input.tsx
+++ b/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-details-comment-input.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Button from '@mui/material/Button'
@@ -12,6 +12,9 @@ import { useAuthContext } from 'src/auth/hooks'
 import { useSnackbar } from 'src/components/snackbar'
 import { CREATE_STAGE_NOTE } from 'src/graphql/mutations'
 import { getStorageFileUrl } from 'src/utils/storage'
+import { useBoolean } from 'src/hooks/use-boolean'
+import { Typography } from '@mui/material'
+import AttachFileModal from 'src/sections/shared/attach-file-modal'
 
 type TProps = {
   stageId: number
@@ -20,20 +23,22 @@ type TProps = {
 
 export default function KanbanDetailsCommentInput(props: TProps) {
   const { stageId, refetch } = props
+  const attachFileModal = useBoolean()
   const { user } = useAuthContext()
-  const [createStageNote, { loading }] = useMutation(CREATE_STAGE_NOTE)
+  const [ createStageNote ] = useMutation(CREATE_STAGE_NOTE)
   const { enqueueSnackbar } = useSnackbar()
 
   const formik = useFormik({
     initialValues: {
       message: '',
+      files: [],
     },
     onSubmit: (values, { resetForm }) => {
       createStageNote({
         variables: {
           message: values.message,
           stageId,
-          files: [],
+          files: values.files,
         },
       })
         .then(() => {
@@ -50,6 +55,18 @@ export default function KanbanDetailsCommentInput(props: TProps) {
         })
     },
   })
+
+  const isDisabled = useMemo(
+    () =>
+      (formik.values.message.length === 0 && formik.values.files.length === 0) ||
+      formik.isSubmitting,
+    [formik.isSubmitting, formik.values]
+  )
+
+  const handleAttachFile = (files: any[]) => {
+    formik.setFieldValue('files', files)
+    attachFileModal.onFalse()
+  }
 
   return (
     <Stack
@@ -83,16 +100,28 @@ export default function KanbanDetailsCommentInput(props: TProps) {
 
         <Stack direction="row" alignItems="center">
           <Stack direction="row" flexGrow={1}>
-            <IconButton disabled>
+            <IconButton onClick={attachFileModal.onTrue}>
               <Iconify icon="eva:attach-2-fill" />
             </IconButton>
+            <Typography variant="body2" sx={{ color: 'text.disabled' }}>
+              {formik.values.files.length === 0 && 'No hay archivos adjuntos'}
+              {formik.values.files.length === 1 && '1 archivo adjunto'}
+              {formik.values.files.length > 1 && `${formik.values.files.length} archivos adjuntos`}
+            </Typography>
           </Stack>
 
-          <Button variant="contained" onClick={() => formik.handleSubmit()} disabled={loading}>
-            Comentar
+          <Button variant="contained" onClick={() => formik.handleSubmit()} disabled={isDisabled}>
+            {formik.isSubmitting ? 'Publicando...' : 'Publicar'}
           </Button>
         </Stack>
       </Paper>
+      {attachFileModal.value && (
+        <AttachFileModal
+          files={formik.values.files}
+          modal={attachFileModal}
+          onSuccess={handleAttachFile}
+        />
+      )}
     </Stack>
   )
 }

--- a/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-details-comment-list.tsx
+++ b/packages/frontend/src/sections/stage/detail/sub-stages-tab/kanban/view/kanban-details-comment-list.tsx
@@ -3,8 +3,11 @@ import React, { useMemo } from 'react'
 import Stack from '@mui/material/Stack'
 import Avatar from '@mui/material/Avatar'
 import Typography from '@mui/material/Typography'
-import { fToNow } from 'src/utils/format-time'
+import { fDate, fToNow } from 'src/utils/format-time'
 import { getStorageFileUrl } from 'src/utils/storage'
+import { Box, Card, Tooltip, Link } from '@mui/material'
+import { fShortenFileSize } from 'src/utils/format-number'
+import FileThumbnail from 'src/components/file-thumbnail/file-thumbnail'
 
 type TProps = {
   notes: IStageNote[]
@@ -45,11 +48,60 @@ export default function KanbanDetailsCommentList(props: TProps) {
               <Typography variant="subtitle2">
                 {note.user ? note.user.fullname : 'No asignado'}
               </Typography>
-              <Typography variant="caption" sx={{ color: 'text.disabled' }}>
-                {fToNow(Number(note.createdAt))}
-              </Typography>
+              <Tooltip title={`${fDate(new Date(Number(note.createdAt) - 3*60*60*1000))} - ${new Date(Number(note.createdAt)).toLocaleTimeString()}`}>
+                <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                  {fToNow(Number(note.createdAt))}
+                </Typography>
+              </Tooltip>
             </Stack>
             <Typography variant="body2">{note.message}</Typography>
+            {note.files && note.files.length > 0 && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: 2,
+                }}
+              >
+                {note.files.map((file) => (
+                  <Box
+                    key={file.id}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <Tooltip title={file.originalName} placement="top">
+                      <Link
+                        href={getStorageFileUrl(file.filename)}
+                        download={file.originalName}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{ textDecoration: 'none' }}
+                      >
+                        <Card
+                          sx={{
+                            p: 1,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <FileThumbnail file="doc" sx={{ width: 36, height: 36 }} />
+                          <Typography
+                            variant="body2"
+                            sx={{ fontSize: '10px', fontWeight: 'bold', color: 'text.disabled' }}
+                          >
+                            {fShortenFileSize(file.size)}
+                          </Typography>
+                        </Card>
+                      </Link>
+                    </Tooltip>
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Stack>
         </Stack>
       ))}


### PR DESCRIPTION
Se agrega la funcionalidad de subir archivos en el modal lateral de las subetapas, dentro del detalle de la etapa.

<img width="733" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/43bb544b-99e2-41c7-b8dc-994480cfd001">
