### PR TITLE
ADP-351

### DIFF
--- a/packages/backend/src/cron/average-completition.ts
+++ b/packages/backend/src/cron/average-completition.ts
@@ -176,13 +176,25 @@ cron.schedule('30 3 * * *', async () => {
 // Run every dat at 00:35 AM (UTC-3)
 // Run every dat at 03:35 AM (UTC)
 cron.schedule('35 3 * * *', async () => {
-  const configuration = await Configuration.findOne({
+  const configurations = await Configuration.findAll({
     where: {
-      key: EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT,
+        [Op.or]: [
+            { key: EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT },
+            { key: EConfigurationKey.PERCENTAGE_ALERT_MARGIN_STAGE }
+        ]
     },
-  })
+  });
+  let percentageAlertMarginProject = 0
+  let percentageAlertMarginStage = 0
 
-  const percentageAlertMargin = configuration ? Number(configuration.value) : 0
+  configurations.forEach((configuration) => {
+    if (configuration.key === EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT) {
+      percentageAlertMarginProject = Number(configuration.value)
+    }
+    else if (configuration.key === EConfigurationKey.PERCENTAGE_ALERT_MARGIN_STAGE) {
+      percentageAlertMarginStage = Number(configuration.value)
+    }
+  })
 
   const areas = await Area.findAll({
     attributes: ['id', 'responsibleId'],
@@ -245,7 +257,7 @@ cron.schedule('35 3 * * *', async () => {
     const currentDate = new Date().toISOString().split('T')[0]
     const days = getDaysDiff(startDate, endDate)
 
-    const expectedDays = Math.round(days * percentageAlertMargin) || 1
+    const expectedDays = Math.round(days * percentageAlertMarginProject) || 1
     const currentDays = getDaysDiff(currentDate, endDate)
 
     let notificationTitle: string | null = null
@@ -283,7 +295,7 @@ cron.schedule('35 3 * * *', async () => {
     const currentDate = new Date().toISOString().split('T')[0]
     const days = getDaysDiff(startDate, endDate)
 
-    const expectedDays = Math.round(days * percentageAlertMargin) || 1
+    const expectedDays = Math.round(days * percentageAlertMarginStage) || 1
     const currentDays = getDaysDiff(currentDate, endDate)
 
     let notificationTitle: string | null = null
@@ -321,7 +333,7 @@ cron.schedule('35 3 * * *', async () => {
     const currentDate = new Date().toISOString().split('T')[0]
     const days = getDaysDiff(startDate, endDate)
 
-    const expectedDays = Math.round(days * percentageAlertMargin) || 1
+    const expectedDays = Math.round(days * percentageAlertMarginStage) || 1
     const currentDays = getDaysDiff(currentDate, endDate)
 
     let notificationTitle: string | null = null

--- a/packages/backend/src/graphql/cron/resolvers.ts
+++ b/packages/backend/src/graphql/cron/resolvers.ts
@@ -195,16 +195,31 @@ export default {
         logger.error(error)
         throw error
       }
-    },
+    },    
     generateAcpNotificationCron: async (_: any, __: any, context: IContext) => {
       try {
         needRole([ROLE_MAP.ADMIN], context)
         if (!context.user) throw new Error('No autorizado')
-        const configuration = await Configuration.findOne({
-          where: { key: EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT },
-        })
 
-        const percentageAlertMargin = configuration ? Number(configuration.value) : 0
+        const configurations = await Configuration.findAll({
+          where: {
+              [Op.or]: [
+                  { key: EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT },
+                  { key: EConfigurationKey.PERCENTAGE_ALERT_MARGIN_STAGE }
+              ]
+          },
+        });
+        let percentageAlertMarginProject = 0
+        let percentageAlertMarginStage = 0
+      
+        configurations.forEach((configuration) => {
+          if (configuration.key === EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT) {
+            percentageAlertMarginProject = Number(configuration.value)
+          }
+          else if (configuration.key === EConfigurationKey.PERCENTAGE_ALERT_MARGIN_STAGE) {
+            percentageAlertMarginStage = Number(configuration.value)
+          }
+        })
 
         const areas = await Area.findAll({
           attributes: ['id', 'responsibleId'],
@@ -275,7 +290,7 @@ export default {
           const currentDate = new Date().toISOString().split('T')[0]
           const days = getDaysDiff(startDate, endDate)
 
-          const expectedDays = Math.round(days * percentageAlertMargin) || 1
+          const expectedDays = Math.round(days * percentageAlertMarginProject) || 1
           const currentDays = getDaysDiff(currentDate, endDate)
 
           let notificationTitle: string | null = null
@@ -315,7 +330,7 @@ export default {
           const currentDate = new Date().toISOString().split('T')[0]
           const days = getDaysDiff(startDate, endDate)
 
-          const expectedDays = Math.round(days * percentageAlertMargin) || 1
+          const expectedDays = Math.round(days * percentageAlertMarginStage) || 1
           const currentDays = getDaysDiff(currentDate, endDate)
 
           let notificationTitle: string | null = null
@@ -355,7 +370,7 @@ export default {
           const currentDate = new Date().toISOString().split('T')[0]
           const days = getDaysDiff(startDate, endDate)
 
-          const expectedDays = Math.round(days * percentageAlertMargin) || 1
+          const expectedDays = Math.round(days * percentageAlertMarginStage) || 1
           const currentDays = getDaysDiff(currentDate, endDate)
 
           let notificationTitle: string | null = null

--- a/packages/frontend/src/sections/configuration/table/config.ts
+++ b/packages/frontend/src/sections/configuration/table/config.ts
@@ -45,9 +45,9 @@ export const COLUMNS: TColumn[] = [
     renderCell: (row: TRow) => {
       switch (row.key) {
         case EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT:
-          return `${Number(row.value) * 100}%`
+          return `${(Number(row.value) * 100).toFixed(0)}%`
         case EConfigurationKey.PERCENTAGE_ALERT_MARGIN_STAGE:
-          return `${Number(row.value) * 100}%`
+          return `${(Number(row.value) * 100).toFixed(0)}%`
         default:
           return row.value
       }
@@ -55,9 +55,9 @@ export const COLUMNS: TColumn[] = [
     searchValue: (row: TRow) => {
       switch (row.key) {
         case EConfigurationKey.PERCENTAGE_ALERT_MARGIN_PROJECT:
-          return `${Number(row.value) * 100}%`
+          return `${(Number(row.value) * 100).toFixed(0)}%`
         case EConfigurationKey.PERCENTAGE_ALERT_MARGIN_STAGE:
-          return `${Number(row.value) * 100}%`
+          return `${(Number(row.value) * 100).toFixed(0)}%`
         default:
           return row.value
       }


### PR DESCRIPTION
Se ajusta el cron de ACP para que tenga en cuenta los 2 valores de alertas.


Ademas:
Se quitan los decimales de la tabla de configuraciones para los 2 valores de alertas.
<img width="1119" alt="image" src="https://github.com/harecode-ar/ADP/assets/38918282/aef9ed69-204b-47f1-ac77-3f1373fa0761">
